### PR TITLE
Shorten MinKNOW samplesheet names and add year dir creation

### DIFF
--- a/VERSIONLOG.md
+++ b/VERSIONLOG.md
@@ -1,5 +1,9 @@
 # Scilifelab_epps Version Log
 
+## 20250122.1
+
+Shorten MinKNOW samplesheet name, so the timestamp is visible in the MinKNOW file explorer. Also add happy-new-year dir creation.
+
 ## 20250116.1
 
 Ruff 0.9.2 formatting.

--- a/scripts/generate_minknow_samplesheet.py
+++ b/scripts/generate_minknow_samplesheet.py
@@ -473,7 +473,7 @@ def generate_MinKNOW_samplesheet(args):
     ), "All rows must have different flow cell positions and IDs"
 
     # Generate samplesheet
-    file_name = f"MinKNOW_samplesheet_{process.id}_{TIMESTAMP}_{process.technician.name.replace(' ', '')}.csv"
+    file_name = f"ONT_ss_{process.id}_{TIMESTAMP}_{process.technician.name.replace(' ', '')}.csv"
     write_minknow_csv(df, file_name)
 
     return file_name
@@ -496,9 +496,13 @@ def main(args):
 
     logging.info("Moving samplesheet to ngi-nas-ns...")
     try:
+        dst = f"/srv/ngi-nas-ns/samplesheets/nanopore/{dt.now().year}"
+        if not os.path.exists(dst):
+            logging.info(f"Happy new year! Creating {dst}")
+            os.mkdir(dst)
         shutil.copyfile(
             file_name,
-            f"/srv/ngi-nas-ns/samplesheets/nanopore/{dt.now().year}/{file_name}",
+            f"{dst}/{file_name}",
         )
         os.remove(file_name)
     except:


### PR DESCRIPTION
Requested by OC since file names are cut off in the MinKNOW file explorer, hiding the timestamp.