### PR TITLE
Trim parenthesized content from sample names in MinKNOW samplesheet

### DIFF
--- a/VERSIONLOG.md
+++ b/VERSIONLOG.md
@@ -1,5 +1,9 @@
 # Scilifelab_epps Version Log
 
+## 20250123.2
+
+Remove parenthesized content from sample names in MinKNOW samplesheet. This is so the input sample location can be shown easily, without having to change the nature of the sequencing step or interfering with the samplesheet downstream.
+
 ## 20250123.1
 
 Shorten MinKNOW samplesheet name, so the timestamp is visible in the MinKNOW file explorer. Also add happy-new-year dir creation.

--- a/scripts/generate_minknow_samplesheet.py
+++ b/scripts/generate_minknow_samplesheet.py
@@ -261,12 +261,15 @@ def get_kit_string(process: Process) -> str:
 
 
 def sanitize_string(string: str) -> str:
-    """Remove potentially problematic characters from string."""
+    """Remove parenthesized content and potentially problematic characters from string."""
 
     # Patterns
+    parenthesized_content = re.compile(r"\([^()]*\)")
     disallowed_characters = re.compile("[^a-zA-Z0-9_-]")
     consecutive_underscores = re.compile("__+")
 
+    # Remove parenthesized content
+    string = parenthesized_content.sub("", string)
     # Replace any disallowed characters with underscores
     string = disallowed_characters.sub("_", string)
     # Remove any consecutive underscores


### PR DESCRIPTION
Remove parenthesized content from sample names in MinKNOW samplesheet. This is so the input sample location can be shown easily, without having to change the nature of the sequencing step or interfering with the samplesheet downstream.