### PR TITLE
AVITI manifest fixes

### DIFF
--- a/scripts/generate_aviti_run_manifest.py
+++ b/scripts/generate_aviti_run_manifest.py
@@ -13,7 +13,7 @@ import pandas as pd
 from genologics.config import BASEURI, PASSWORD, USERNAME
 from genologics.entities import Process
 from genologics.lims import Lims
-from Levenshtein import hamming as distance
+from Levenshtein import distance
 
 from data.Chromium_10X_indexes import Chromium_10X_indexes
 from scilifelab_epps.epp import upload_file

--- a/scripts/generate_aviti_run_manifest.py
+++ b/scripts/generate_aviti_run_manifest.py
@@ -169,7 +169,7 @@ def get_manifests(process: Process, manifest_root_name: str) -> list[tuple[str, 
         # Get sample-label linkage via database
         sample2label: dict[str, str] = get_pool_sample_label_mapping(pool)
         assert len(set(pool.reagent_labels)) == len(pool.reagent_labels), (
-            "Detected non-unique reagent labels."
+            f"Detected non-unique reagent labels in lane {lane}"
         )
 
         # Record PhiX UDFs for each output artifact

--- a/scripts/generate_aviti_run_manifest.py
+++ b/scripts/generate_aviti_run_manifest.py
@@ -292,6 +292,8 @@ def make_manifest(
     manifest_root_name: str,
     manifest_type: str,
 ) -> tuple[str, str | None]:
+    logging.info(f"Building {manifest_type} manifest...")
+
     # Get the index cycles from the step fields
     idx1_cycles = int(process.udf.get("Index Read 1"))
     idx2_cycles = int(process.udf.get("Index Read 2"))

--- a/scripts/generate_aviti_run_manifest.py
+++ b/scripts/generate_aviti_run_manifest.py
@@ -158,7 +158,6 @@ def get_manifests(process: Process, manifest_root_name: str) -> list[tuple[str, 
 
     # Assert lanes
     lanes = [art_out.location[1].split(":")[0] for art_out in arts_out]
-    lanes.sort()
     assert set(lanes) == {"1"} or set(lanes) == {
         "1",
         "2",
@@ -166,7 +165,7 @@ def get_manifests(process: Process, manifest_root_name: str) -> list[tuple[str, 
 
     # Iterate over pool / lane
     sample_rows = []
-    for pool, lane in zip(arts_out, lanes):
+    for pool, lane in sorted(zip(arts_out, lanes), key=lambda x: x[1]):
         # Get sample-label linkage via database
         sample2label: dict[str, str] = get_pool_sample_label_mapping(pool)
         assert len(set(pool.reagent_labels)) == len(pool.reagent_labels), (

--- a/scripts/generate_aviti_run_manifest.py
+++ b/scripts/generate_aviti_run_manifest.py
@@ -333,6 +333,7 @@ def make_manifest(
         samples_section = f"[SAMPLES]\n{df.to_csv(index=None, header=True)}"
 
     elif manifest_type == "trimmed":
+        # Equalize index lengths to shortest
         min_idx1_len = df["Index1"].apply(len).min()
         min_idx2_len = df["Index2"].apply(len).min()
         df["Index1"] = df["Index1"].apply(lambda x: x[:min_idx1_len])
@@ -341,7 +342,15 @@ def make_manifest(
         samples_section = f"[SAMPLES]\n{df.to_csv(index=None, header=True)}"
 
     elif manifest_type == "phix":
+        # Subset to PhiX controls
         df = df[df["Project"] == "Control"]
+        # Trim PhiX indices to match run settings
+        idx1_cycles = int(process.udf.get("Index Read 1", 0))
+        idx2_cycles = int(process.udf.get("Index Read 2", 0))
+        if idx1_cycles < df["Index1"].apply(len).max():
+            df["Index1"] = df["Index1"].apply(lambda x: x[:idx1_cycles])
+        if idx2_cycles < df["Index2"].apply(len).max():
+            df["Index2"] = df["Index2"].apply(lambda x: x[:idx2_cycles])
         samples_section = f"[SAMPLES]\n{df.to_csv(index=None, header=True)}"
 
     elif manifest_type == "empty":

--- a/scripts/generate_aviti_run_manifest.py
+++ b/scripts/generate_aviti_run_manifest.py
@@ -377,7 +377,7 @@ def make_manifest(
             )
             i1_mismatch, i2_mismatch = get_custom_mistmatch_thresholds(df)
         except AssertionError as e:
-            logging.error(e, exc_info=True)
+            logging.error(e)
             logging.error(
                 f"Could not generate {manifest_type} manifest without index collisions. Skipping."
             )

--- a/scripts/generate_aviti_run_manifest.py
+++ b/scripts/generate_aviti_run_manifest.py
@@ -545,18 +545,16 @@ def main(args: Namespace):
     # Create manifest(s)
     manifests: list[tuple[str, str | None]] = get_manifests(process, manifest_root_name)
 
-    # Write manifest(s)
-    for file, content in manifests:
-        if content:
-            open(file, "w").write(content)
-
-    # Zip manifest(s)
+    # Write and zip manifest(s)
     zip_file = f"{manifest_root_name}.zip"
-    files = [file for file, _ in manifests]
     with ZipFile(zip_file, "w") as zip_stream:
-        for file in files:
-            zip_stream.write(file)
-            os.remove(file)
+        for file, content in manifests:
+            if content:
+                open(file, "w").write(content)
+                zip_stream.write(file)
+                os.remove(file)
+            else:
+                logging.warning(f"Not writing {file} due to missing contents.")
 
     # Upload manifest(s)
     logging.info("Uploading run manifest to LIMS...")

--- a/scripts/generate_aviti_run_manifest.py
+++ b/scripts/generate_aviti_run_manifest.py
@@ -173,9 +173,9 @@ def get_manifests(process: Process, manifest_root_name: str) -> list[tuple[str, 
         )
 
         # Record PhiX UDFs for each output artifact
-        phix_loaded: bool = pool.udf["% phiX"] != 0
-        phix_set_name = pool.udf.get("Element PhiX Set", None)
-        if phix_loaded:
+        phix_loaded: float = pool.udf.get("% phiX", 0)
+        phix_set_name: str | None = pool.udf.get("Element PhiX Set", None)
+        if phix_loaded != 0:
             assert phix_set_name is not None, (
                 "PhiX controls loaded but no kit specified."
             )

--- a/scripts/generate_aviti_run_manifest.py
+++ b/scripts/generate_aviti_run_manifest.py
@@ -326,7 +326,7 @@ def make_manifest(
     if manifest_type == "untrimmed":
         samples_section = f"[SAMPLES]\n{df.to_csv(index=None, header=True)}"
 
-    elif manifest_type == "trimmed" or manifest_type == "phix":
+    elif manifest_type in ["trimmed", "phix"]:
         if manifest_type == "phix":
             # Subset to PhiX controls
             df = df[df["Project"] == "Control"]
@@ -368,7 +368,7 @@ def make_manifest(
     )
 
     # Customize mismatch thresholds, if necessary
-    if manifest_type != "empty":
+    if manifest_type not in ["untrimmed", "empty"]:
         try:
             logging.info(
                 f"Getting custom mismatch thresholds for {manifest_type} manifest..."

--- a/scripts/generate_aviti_run_manifest.py
+++ b/scripts/generate_aviti_run_manifest.py
@@ -323,6 +323,9 @@ def make_manifest(
         [
             "[SETTINGS]",
             "SettingName, Value",
+            # Mismatch thresholds set to 0 to allow identical I1 xor I2
+            "I1MismatchThreshold, 0",
+            "I2MismatchThreshold, 0",
         ]
     )
 


### PR DESCRIPTION
- Tweak settings section to allow for identical I1 xor I2
- Trim down PhiX indices in PhiX manifest based on supplied run recipe