### PR TITLE
Patch reads aggregation EPP

### DIFF
--- a/VERSIONLOG.md
+++ b/VERSIONLOG.md
@@ -1,5 +1,9 @@
 # Scilifelab_epps Version Log
 
+## 20250205.1
+
+Introduce patch to reads aggregation EPP so opened steps don't have to be re-started from scratch.
+
 ## 20250201.1
 
 Renovate reads aggregation EPP and include ONT / AVITI.

--- a/scilifelab_epps/wrapper.py
+++ b/scilifelab_epps/wrapper.py
@@ -52,7 +52,7 @@ def epp_decorator(script_path: str, timestamp: str):
             # Start logging
             logging.info(f"Script '{script_name}' started at {timestamp}.")
             logging.info(
-                f"Launched in step '{process.type.name}' ({process.id}) by {process.technician.name}."
+                f"Launched in step '{process.type.name}' ({process.id}) opened by {process.technician.name}."
             )
             args_str = "\n\t".join(
                 [f"'{arg}': {getattr(args, arg)}" for arg in vars(args)]


### PR DESCRIPTION
In the re-writing of this EPP, I decided to keep the weird summary file that nobody knew what it does.

It used to be uploaded to the "AggregationLog" file slot which is now instead used for the standard EPP log. I created a new file slot "AggregationSummary" to move it to.

The issue is that step file slots are not updated until you restart the step, so this will become an issue when running reads aggregation for the hundred or so open project summary steps we have.

This patch will simply skip trying to upload the summary file, if it cannot find its file slot.