### PR TITLE
Bugfix AVITI demux script

### DIFF
--- a/VERSIONLOG.md
+++ b/VERSIONLOG.md
@@ -1,5 +1,9 @@
 # Scilifelab_epps Version Log
 
+## 20250206.1
+
+Bugfix demux script by skipping outputs that do not contain the relevant sample name.
+
 ## 20250205.1
 
 Introduce patch to reads aggregation EPP so opened steps don't have to be re-started from scratch.

--- a/scripts/manage_demux_stats.py
+++ b/scripts/manage_demux_stats.py
@@ -857,9 +857,9 @@ def write_demuxfile_aviti(process_stats, demux_id):
                             "% of thelane": float(
                                 row.get("PercentPoloniesAssigned", "0")
                             ),
-                            "% >= Q30bases": float(row.get("PercentQ30", "0")),
+                            "% >= Q30bases": float(row.get("PercentQ30", "0") or 0),
                             "Mean QualityScore": float(
-                                row.get("QualityScoreMean", "0")
+                                row.get("QualityScoreMean", "0") or 0
                             ),
                             "% Perfectbarcode": 100
                             - float(row.get("PercentMismatch", "0")),

--- a/scripts/manage_demux_stats.py
+++ b/scripts/manage_demux_stats.py
@@ -335,6 +335,9 @@ def set_sample_values(demux_process, parser_struct, process_stats):
                     "exit",
                     f"Unable to determine sample name. Incorrect sample variable in process: {str(e)}",
                 )
+            # Skip artifacts that are not sample-related
+            if current_name not in target_file.name:
+                continue
             for entry in parser_struct:
                 if lane_no == entry["Lane"]:
                     sample = entry["Sample"]


### PR DESCRIPTION
This file is quite old and complex (13 levels of indentation yay!) but I've attempted to make a simple bugfix by skipping outputs that do not contain the relevant sample name.