### PR TITLE
Update formulas to match updated NEB calc tool, assuming deprotonated phosphate hydroxyls

### DIFF
--- a/VERSIONLOG.md
+++ b/VERSIONLOG.md
@@ -1,5 +1,9 @@
 # Scilifelab_epps Version Log
 
+## 20250304.1
+
+Update formulas to match updated [NEB calc tool](https://nebiocalculator.neb.com/#!/dsdnaamt), assuming deprotonated phosphate hydroxyls.
+
 ## 20250218.1
 
 Bugfix demux script by skipping outputs that do not contain the relevant sample name.

--- a/scilifelab_epps/utils/formula.py
+++ b/scilifelab_epps/utils/formula.py
@@ -10,7 +10,7 @@ def ng_to_fmol(ng, bp):
     Formula based on NEBioCalculator
     https://nebiocalculator.neb.com/#!/dsdnaamt
     """
-    return 10**6 * ng / (bp * 617.96 + 36.04)
+    return 10**6 * ng / (bp * 615.96 + 36.04)
 
 
 def ng_ul_to_nM(ng_ul, bp):
@@ -23,7 +23,7 @@ def fmol_to_ng(fmol, bp):
     Formula based on NEBioCalculator
     https://nebiocalculator.neb.com/#!/dsdnaamt
     """
-    return fmol * (bp * 617.96 + 36.04) / 10**6
+    return fmol * (bp * 615.96 + 36.04) / 10**6
 
 
 def nM_to_ng_ul(nM, bp):


### PR DESCRIPTION
This change touches a lot of accredited EPPs, but it's very straight forward in what it does and the reasoning behind it.