### PR TITLE
Introduce work-around for LIMS bug of demux artifacts having multiple sample associations

### DIFF
--- a/VERSIONLOG.md
+++ b/VERSIONLOG.md
@@ -1,6 +1,6 @@
 # Scilifelab_epps Version Log
 
-## 20250401.1
+## 20250408.1
 
 Introduce new EPP to fix bugged demux artifacts with multiple samples in the name by using sample-label linkage to identify the "correct" sample and rename the demux artifact accordingly.
 Demux EPP: Add logic block to handle demux artifacts being tied to multiple samples, in which case try to choose a single sample matching the name of the demux artifact.

--- a/VERSIONLOG.md
+++ b/VERSIONLOG.md
@@ -1,5 +1,9 @@
 # Scilifelab_epps Version Log
 
+## 20250401.1
+
+Demux EPP: Add logic block to handle demux artifacts being tied to multiple samples, in which case try to choose a single sample matching the name of the demux artifact.
+
 ## 20250327.1
 
 Re-work ONT barcoding module and it's application for MinKNOW samplesheet generation.

--- a/scilifelab_epps/epp.py
+++ b/scilifelab_epps/epp.py
@@ -16,6 +16,8 @@ from logging.handlers import RotatingFileHandler
 from shutil import copy
 from time import localtime, strftime
 
+import psycopg2
+import yaml
 from genologics.config import MAIN_LOG
 from genologics.entities import Artifact, Process
 from genologics.lims import Lims
@@ -568,3 +570,64 @@ def upload_file(
     if remove:
         os.remove(file_path)
         logging.info(f"'{file_path}' removed from local filesystem.")
+
+
+def get_pool_sample_label_mapping(pool: Artifact) -> dict[str, str]:
+    """Given a pool artifact containing labeled samples, use database queries to
+    build a dictionary mapping each sample name to its reagent label.
+    """
+    with open("/opt/gls/clarity/users/glsai/config/genosqlrc.yaml") as f:
+        config = yaml.safe_load(f)
+
+    # Setup DB connection
+    connection = psycopg2.connect(
+        user=config["username"],
+        host=config["url"],
+        database=config["db"],
+        password=config["password"],
+    )
+    cursor = connection.cursor()
+
+    # Find all reagent labels linked to 'analyte' type artifacts matching the given name
+    query = """
+        select
+            distinct( rl.name )
+        from
+            reagentlabel            rl,
+            artifact                art,
+            artifact_label_map      alm
+        where
+            rl.labelid              = alm.labelid
+            and art.artifactid      = alm.artifactid
+            and art.artifacttypeid  = 2
+            and art.name            = '{}';
+    """
+
+    errors = False
+    sample2label = {}
+    for sample in pool.samples:
+        try:
+            cursor.execute(query.format(sample.name))
+            query_results = cursor.fetchall()
+
+            assert len(query_results) != 0, (
+                f"No reagent labels found for sample '{sample.name}'."
+            )
+            assert len(query_results) == 1, (
+                f"Multiple reagent labels found for sample '{sample.name}'."
+            )
+
+            label = query_results[0][0]
+            sample2label[sample.name] = label
+        except AssertionError as e:
+            logging.error(str(e), exc_info=True)
+            logging.warning(f"Skipping sample '{sample.name}' due to error.")
+            errors = True
+            continue
+
+    if errors:
+        raise AssertionError(
+            "Errors occurred when linking samples and indices. Please report this error."
+        )
+    else:
+        return sample2label

--- a/scripts/fix_demux_artifact_names.py
+++ b/scripts/fix_demux_artifact_names.py
@@ -36,7 +36,7 @@ from genologics.config import BASEURI, PASSWORD, USERNAME
 from genologics.entities import Process
 from genologics.lims import Lims
 
-from scripts.generate_minknow_samplesheet import get_pool_sample_label_mapping
+from scilifelab_epps.epp import get_pool_sample_label_mapping
 
 TIMESTAMP = dt.now().strftime("%y%m%d_%H%M%S")
 

--- a/scripts/fix_demux_artifact_names.py
+++ b/scripts/fix_demux_artifact_names.py
@@ -37,10 +37,12 @@ from genologics.entities import Process
 from genologics.lims import Lims
 
 from scilifelab_epps.epp import get_pool_sample_label_mapping
+from scilifelab_epps.wrapper import epp_decorator
 
 TIMESTAMP = dt.now().strftime("%y%m%d_%H%M%S")
 
 
+@epp_decorator(__file__, TIMESTAMP)
 def main(args: Namespace):
     lims = Lims(BASEURI, USERNAME, PASSWORD)
     process = Process(lims, id=args.pid)

--- a/scripts/fix_demux_artifact_names.py
+++ b/scripts/fix_demux_artifact_names.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python
+DESC = """
+This script adresses a specific LIMS bug in which the demux artifacts of a
+demultiplexing step are associated to multiple samples, instead of a single sample.
+
+The bug is described in deviation #312 on AM.
+
+I.e. a list of demux artifacts for a pool which should be e.g.
+    P34304_1004 (FASTQ reads)
+    P34304_1005 (FASTQ reads)
+    P34304_1006 (FASTQ reads)
+instead becomes e.g.
+    P34304_1004 + P34304_1005 + P34304_1006 (FASTQ reads)
+    P34304_1005 + P34304_1006 (FASTQ reads)
+    P34304_1005 + P34304_1006 (FASTQ reads)
+
+The identity of each demux artifact is dubious, but they do appear to maintain
+the correct reagent label.
+
+This script
+ - Iterates through each pool in the process
+    - Creates an SQL-derived sample-label mapping for the pool contents
+    - Iterates through each demux artifact associated with the pool
+        - Uses the sample-label mapping to find the "correct" sample name
+        - Renames the demux artifact to the "correct" sample name
+
+The demux artifacts will still have multiple samples associated with them, but at least
+the name will be corrected to facilitate downstream processing.
+
+"""
+import logging
+from argparse import ArgumentParser, Namespace
+from datetime import datetime as dt
+
+from genologics.config import BASEURI, PASSWORD, USERNAME
+from genologics.entities import Process
+from genologics.lims import Lims
+
+from scripts.generate_minknow_samplesheet import get_pool_sample_label_mapping
+
+TIMESTAMP = dt.now().strftime("%y%m%d_%H%M%S")
+
+
+def main(args: Namespace):
+    lims = Lims(BASEURI, USERNAME, PASSWORD)
+    process = Process(lims, id=args.pid)
+
+    pools = process.all_inputs()
+    for pool in pools:
+        # Get sample-label mapping for the pool
+        logging.info(f"Getting sample-label mapping for pool '{pool.name}' ({pool.id})")
+        sample2label = get_pool_sample_label_mapping(pool)
+
+        # Collect demux artifacts associated with pool
+        demux_arts = []
+        for art_tuple in process.input_output_maps:
+            if (
+                art_tuple[0]["uri"].id == pool.id
+                and art_tuple[1]["output-generation-type"] == "PerReagentLabel"
+            ):
+                demux_arts.append(art_tuple[1]["uri"])
+
+        # Iterate across demux arts
+        for demux_art in demux_arts:
+            # Get reagent label
+            assert len(demux_art.reagent_labels) == 1, (
+                f"Demux artifact '{demux_art.name}' ({demux_art.id}) "
+                + " has multiple labels. That should not happen."
+            )
+            label = demux_art.reagent_labels[0]
+
+            # Use sample-label mapping to find the "correct" sample name
+            correct_sample_name = None
+            for sample in demux_art.samples:
+                if sample.name in sample2label and sample2label[sample.name] == label:
+                    correct_sample_name = sample.name
+                    break
+            if correct_sample_name is None:
+                msg = (
+                    "Could not find correct sample name"
+                    + f" for demux artifact '{demux_art.name}' ({demux_art.id}) "
+                    + f" in pool {pool.id}. Skipping."
+                )
+                logging.error(msg)
+                continue
+
+            new_name = f"{correct_sample_name} (FASTQ reads)"
+            logging.info(f"Renaming '{demux_art.name}' -> '{new_name}'")
+            demux_art.name = new_name
+            demux_art.put()
+
+
+if __name__ == "__main__":
+    # Parse args
+    parser = ArgumentParser()
+    parser.add_argument(
+        "--pid",
+        required=True,
+        type=str,
+        help="Lims ID for current Process.",
+    )
+    parser.add_argument(
+        "--log",
+        required=True,
+        type=str,
+        help="Which file slot to use for the script log.",
+    )
+    args = parser.parse_args()
+
+    main(args)

--- a/scripts/fix_demux_artifact_names.py
+++ b/scripts/fix_demux_artifact_names.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 DESC = """
-This script adresses a specific LIMS bug in which the demux artifacts of a
+This script addresses a specific LIMS bug in which the demux artifacts of a
 demultiplexing step are associated to multiple samples, instead of a single sample.
 
 The bug is described in deviation #312 on AM.
@@ -84,10 +84,19 @@ def main(args: Namespace):
                 logging.error(msg)
                 continue
 
-            new_name = f"{correct_sample_name} (FASTQ reads)"
-            logging.info(f"Renaming '{demux_art.name}' -> '{new_name}'")
-            demux_art.name = new_name
-            demux_art.put()
+            correct_demux_art_name = f"{correct_sample_name} (FASTQ reads)"
+            if correct_demux_art_name == demux_art.name:
+                logging.info(
+                    f"Demux artifact '{demux_art.name}' ({demux_art.id}) "
+                    + "already has the correct name. Skipping."
+                )
+                continue
+            else:
+                logging.info(
+                    f"Renaming '{demux_art.name}' -> '{correct_demux_art_name}'"
+                )
+                demux_art.name = correct_demux_art_name
+                demux_art.put()
 
 
 if __name__ == "__main__":

--- a/scripts/fix_demux_artifact_names.py
+++ b/scripts/fix_demux_artifact_names.py
@@ -95,7 +95,7 @@ def main(args: Namespace):
                 continue
             else:
                 logging.info(
-                    f"Renaming '{demux_art.name}' -> '{correct_demux_art_name}'"
+                    f"Renaming '{demux_art.name}' ({demux_art.id}) -> '{correct_demux_art_name}'"
                 )
                 demux_art.name = correct_demux_art_name
                 demux_art.put()

--- a/scripts/generate_aviti_run_manifest.py
+++ b/scripts/generate_aviti_run_manifest.py
@@ -16,9 +16,8 @@ from genologics.lims import Lims
 from Levenshtein import distance
 
 from data.Chromium_10X_indexes import Chromium_10X_indexes
-from scilifelab_epps.epp import upload_file
+from scilifelab_epps.epp import get_pool_sample_label_mapping, upload_file
 from scilifelab_epps.wrapper import epp_decorator
-from scripts.generate_minknow_samplesheet import get_pool_sample_label_mapping
 
 TIMESTAMP = dt.now().strftime("%y%m%d_%H%M%S")
 

--- a/scripts/manage_demux_stats.py
+++ b/scripts/manage_demux_stats.py
@@ -329,7 +329,26 @@ def set_sample_values(demux_process, parser_struct, process_stats):
         # Artifacts in each lane
         for target_file in outarts_per_lane:
             try:
-                current_name = target_file.samples[0].name
+                # This block adresses a LIMS bug in which multiple samples are tied to the same demux artifact
+                # In this case, try to find a single sample name matching the name of the demux artifact
+                if len(target_file.samples) > 1:
+                    matching_names = [
+                        sample.name
+                        for sample in target_file.samples
+                        if sample.name in target_file.name
+                    ]
+                    if len(matching_names) > 1:
+                        raise AssertionError(
+                            "Multiple samples tied to demux artifact more than one sample name matches demux artifact name."
+                        )
+                    elif len(matching_names) == 0:
+                        raise AssertionError(
+                            "Multiple samples tied to demux artifact no sample name matches demux artifact name."
+                        )
+                    else:
+                        current_name = matching_names[0]
+                else:
+                    current_name = target_file.samples[0].name
             except Exception as e:
                 problem_handler(
                     "exit",

--- a/scripts/manage_demux_stats.py
+++ b/scripts/manage_demux_stats.py
@@ -329,7 +329,7 @@ def set_sample_values(demux_process, parser_struct, process_stats):
         # Artifacts in each lane
         for target_file in outarts_per_lane:
             try:
-                # This block adresses a LIMS bug in which multiple samples are tied to the same demux artifact
+                # This block addresses a LIMS bug in which multiple samples are tied to the same demux artifact
                 # In this case, try to find a single sample name matching the name of the demux artifact
                 if len(target_file.samples) > 1:
                     matching_names = [

--- a/scripts/ont_sync_to_db.py
+++ b/scripts/ont_sync_to_db.py
@@ -179,9 +179,9 @@ def sync_runs_to_db(process: Process, args: Namespace, lims: Lims):
 
     # Assert that only one input is provided for QC runs
     if "QC" in process.type.name:
-        assert (
-            len(arts) == 1
-        ), "When starting QC sequencing runs, only one input is allowed."
+        assert len(arts) == 1, (
+            "When starting QC sequencing runs, only one input is allowed."
+        )
 
     # Keep track of which artifacts were successfully updated
     arts_successful = []


### PR DESCRIPTION
This PR adresses a specific LIMS bug in which the demux artifacts of a
demultiplexing step are associated to multiple samples, instead of a single sample.

The bug is described in deviation 312 on AM and can be demonstrated here
https://ngi-lims-prod.scilifelab.se/clarity/work-details/1158615

I.e. a list of demux artifacts for a pool which should be e.g.
    P34304_1004 (FASTQ reads)
    P34304_1005 (FASTQ reads)
    P34304_1006 (FASTQ reads)
instead becomes e.g.
    P34304_1004 + P34304_1005 + P34304_1006 (FASTQ reads)
    P34304_1005 + P34304_1006 (FASTQ reads)
    P34304_1005 + P34304_1006 (FASTQ reads)

The identity of each demux artifact is dubious, but they do appear to maintain
the correct reagent label.

This script
 - Iterates through each pool in the process
    - Creates an SQL-derived sample-label mapping for the pool contents
    - Iterates through each demux artifact associated with the pool
        - Uses the sample-label mapping to find the "correct" sample name
        - Renames the demux artifact to the "correct" sample name

The demux artifacts will still have multiple samples associated with them, but at least
the name will be corrected to facilitate downstream processing.

The following open step on LIMS prod is intended to be used for live development and experimental deployment
https://ngi-lims-prod.scilifelab.se/clarity/work-details/1172314
