### PR TITLE
Replace None with "" for writing N/A AVITI parameters to UDFs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ As of now, we use:
 - [mypy](https://mypy.readthedocs.io/en/stable/) for static type checking and to prevent contradictory type annotation.
   - Run with `mypy **/*.py`
 - [pipreqs](https://github.com/bndr/pipreqs) to check that the requirement files are up-to-date with the code.
-
   - This is run with a custom Bash script in GitHub Actions which will only compare the list of package names.
 
     ```

--- a/VERSIONLOG.md
+++ b/VERSIONLOG.md
@@ -1,5 +1,9 @@
 # Scilifelab_epps Version Log
 
+## 20250723.1
+
+Replace None with "" for writing N/A AVITI parameters to UDFs.
+
 ## 20250602.1
 
 Add assertion for demux parsing to prevent multiple flowcells in step.

--- a/scripts/aviti_run_parameter_parser.py
+++ b/scripts/aviti_run_parameter_parser.py
@@ -152,7 +152,7 @@ def parse_run_stats(run_dir):
 
 def calculate_mean(input_list, key):
     values = [d[key] for d in input_list if key in d and d[key] > 0]
-    mean_value = sum(values) / len(values) if values else None
+    mean_value = sum(values) / len(values) if values else ""
     return mean_value
 
 


### PR DESCRIPTION
[It failed here](https://ngi-lims-prod.scilifelab.se/clarity/work-details/1214050) due to missing R2 parameters and no PhiX. Can't write None object to a UDF, replace with empty string.